### PR TITLE
text roulette app

### DIFF
--- a/apps/text-roulette.rb
+++ b/apps/text-roulette.rb
@@ -1,0 +1,18 @@
+class TextRoulette < Dumbstore::App
+  author 'quantumpotato'
+  author_url 'https://github.com/quantumpotato'
+  description 'leave a message, take a message'
+
+  text_id 'tr'
+
+  def text params
+    new_message = params['Body']
+    #post new message to server and return response
+    new_message.sub!(' ', '%20')
+    u = URI.parse("http://dumbtextroulette.herokuapp.com/#{new_message}")
+    msg = Net::HTTP.get_response(u).body
+    "<Response><Sms>#{msg}</Sms><Response>"
+  end
+
+end
+


### PR DESCRIPTION
leave a message, take a message.

I tested this on the command line against my heroku server and it worked.

I was unable to test with the dumbstore server as the twilio id was missing.

I selected 'tr' as a code because texting text-roulette <msg> seemed like bad UX.

However, this leaves an ambiguous app name 'tr'. If this is a problem please comment so I can change the app name.

Thank you
